### PR TITLE
fix: panel shouldn't be destroy

### DIFF
--- a/src/pages/admin/components/TabView.vue
+++ b/src/pages/admin/components/TabView.vue
@@ -13,6 +13,7 @@
       :tab="panel.name"
       :name="panel.index"
       scrolling-y="auto"
+      display-directive="show"
     >
       <iframe
         frameborder="0"


### PR DESCRIPTION
title